### PR TITLE
New change observer API

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,11 +219,21 @@ cannot use your implementation in a calendar view. It's implemented inside the l
 
 - `getTimeZone()/setTimeZone()` to get or set calendar's time zone. By default, it's default system time
   zone (`TimeZone.getDefault()`). Calendar's time zone affects to "today" cell recognition. When new time zone is set, "
-  today" cell is updated. If new value (not system default one) is set, system time zone changes become unobserved due
-  to the assumption that when custom time zone is set, it's expected that calendar's time zone wouldn't be overwritten
-  when system time zone is changed.
-- `getObserveTimeZoneChanges()/setObserveTimeZoneChanges()` to get or set whether system time zone changes should be
-  observed.
+  today" cell is updated.
+
+## Observing date and time-zone changes
+
+This can be done manually by registering an `BroadcastReceiver` and updating time zone via `setTimeZone()` or notifying about today's date change via `notifyTodayChanged()`.
+Or `RangeCalendarConfigObserver` can be used that, basically, does the same thing. The class is also lifecycle-aware.
+Example:
+```kotlin
+val observer = RangeCalendarConfigObserver(rangeCalendar).apply { 
+    observeDateChanges = false // if we don't want rangeCalendar to be notified about these changes.
+    observeTimeZoneChanges = true // by default, it's true. But can also be disabled.
+}
+observer.setLifecycle(lifecycle) // If we want to unregister the observer on destroy.
+observer.register() // The observer should be registered manually.
+```
 
 ## Other
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -48,6 +48,8 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
+    androidTestImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
 }
 
 afterEvaluate {

--- a/library/src/androidTest/AndroidManifest.xml
+++ b/library/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application android:theme="@style/Theme.AppCompat">
+        <activity android:name="com.github.pelmenstar1.rangecalendar.RangeCalendarConfigObserverTests$TestActivity"/>
+    </application>
+</manifest>

--- a/library/src/androidTest/java/com/github/pelmenstar1/rangecalendar/RangeCalendarConfigObserverTests.kt
+++ b/library/src/androidTest/java/com/github/pelmenstar1/rangecalendar/RangeCalendarConfigObserverTests.kt
@@ -1,0 +1,106 @@
+package com.github.pelmenstar1.rangecalendar
+
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.SimpleTimeZone
+import java.util.TimeZone
+import kotlin.test.assertEquals
+
+@RunWith(AndroidJUnit4::class)
+class RangeCalendarConfigObserverTests {
+    class TestActivity : AppCompatActivity() {
+        override fun onCreate(savedInstanceState: Bundle?) {
+            super.onCreate(savedInstanceState)
+
+            setContentView(View(this))
+        }
+    }
+
+    private val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+    private val testTimeZone = SimpleTimeZone(123, "TestTZ")
+
+    private fun createTimeZoneChangedIntent(): Intent {
+        return Intent(Intent.ACTION_TIMEZONE_CHANGED).apply {
+            if (Build.VERSION.SDK_INT >= 30) {
+                putExtra(Intent.EXTRA_TIMEZONE, testTimeZone)
+            }
+        }
+    }
+
+    private fun createDateChangedIntent(): Intent {
+        return Intent(Intent.ACTION_DATE_CHANGED)
+    }
+
+    private fun useCalendarView(block: (RangeCalendarView) -> Unit) {
+        ActivityScenario.launch(TestActivity::class.java).onActivity {
+            block(RangeCalendarView(it))
+        }
+    }
+
+    // Unfortunately, we can't change current time zone programmatically. So we can't directly test
+    // the handling of Intent.ACTION_TIMEZONE_CHANGED event. To workaround, the intent sent by the system
+    // is emulated and the method that handles these intents (RangeCalendarConfigObserver.onReceiveBroadcast) is called.
+    @Test
+    fun timeZoneChangedTest() = useCalendarView { calendar ->
+        val oldTz = TimeZone.getDefault()
+        TimeZone.setDefault(testTimeZone)
+
+        try {
+            RangeCalendarConfigObserver(calendar).onBroadcastReceived(createTimeZoneChangedIntent())
+            assertEquals(testTimeZone, calendar.timeZone)
+        } finally {
+            TimeZone.setDefault(oldTz)
+        }
+    }
+
+    @Test
+    fun disableTimeZoneChangeNotificationsTest() = useCalendarView { calendar ->
+        val observer = RangeCalendarConfigObserver(calendar).apply {
+            observeTimeZoneChanges = false
+        }
+
+        val oldTz = calendar.timeZone
+        observer.onBroadcastReceived(createTimeZoneChangedIntent())
+
+        // Assure that timeZone wasn't changed.
+        assertEquals(oldTz, calendar.timeZone)
+    }
+
+    // Unfortunately, we can't change current time zone programmatically. So we can't directly test
+    // the handling of Intent.ACTION_DATE_CHANGED event. To check that the logic actually calls
+    // RangeCalendarView.notifyTodayChanged(), we firstly set the today's date to a fake one, then
+    // emulate the broadcast intent and check if the today's date is actually today.
+    @Test
+    fun dateChangedTest() = useCalendarView { calendar ->
+        val testDate = PackedDate(year = 1, month = 1, dayOfMonth = 1)
+        val expectedDate = PackedDate.today()
+
+        calendar.adapter.setToday(testDate)
+        RangeCalendarConfigObserver(calendar).onBroadcastReceived(createDateChangedIntent())
+
+        assertEquals(expectedDate, calendar.adapter.today)
+    }
+
+    @Test
+    fun disableDateChangeNotificationsTest() = useCalendarView { calendar ->
+        val observer = RangeCalendarConfigObserver(calendar).apply {
+            observeDateChanges = false
+        }
+
+        val testDate = PackedDate(year = 1, month = 1, dayOfMonth = 1)
+        calendar.adapter.setToday(testDate)
+
+        observer.onBroadcastReceived(createDateChangedIntent())
+
+        // We disabled date change notifications, so today's date should remain the same
+        assertEquals(testDate, calendar.adapter.today)
+    }
+}

--- a/library/src/main/java/com/github/pelmenstar1/rangecalendar/CompatDateFormatter.kt
+++ b/library/src/main/java/com/github/pelmenstar1/rangecalendar/CompatDateFormatter.kt
@@ -8,7 +8,7 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
-internal class CompatDateFormatter(private val context: Context, private val pattern: String) {
+internal class CompatDateFormatter(context: Context, private val pattern: String) {
     // If API >= 24, the type should be android.icu.text.SimpleDateFormat,
     // otherwise java.text.SimpleDateFormat.
     private var dateFormatter: Any? = null
@@ -50,21 +50,24 @@ internal class CompatDateFormatter(private val context: Context, private val pat
         val buffer = stringBuffer
         buffer.setLength(0)
 
-        return if (Build.VERSION.SDK_INT >= 24) {
+        // Use the appropriate formatter
+        if (Build.VERSION.SDK_INT >= 24) {
             val formatter = dateFormatter as android.icu.text.SimpleDateFormat
             val calendar = calendarOrDate as android.icu.util.Calendar
 
             calendar.timeInMillis = millis
 
-            formatter.format(calendar, buffer, FIELD_POS).toString()
+            formatter.format(calendar, buffer, FIELD_POS)
         } else {
             val formatter = dateFormatter as SimpleDateFormat
             val javaUtilDate = calendarOrDate as Date
 
             javaUtilDate.time = millis
 
-            formatter.format(javaUtilDate, buffer, FIELD_POS).toString()
+            formatter.format(javaUtilDate, buffer, FIELD_POS)
         }
+
+        return buffer.toString()
     }
 
     companion object {

--- a/library/src/main/java/com/github/pelmenstar1/rangecalendar/CompatDateFormatter.kt
+++ b/library/src/main/java/com/github/pelmenstar1/rangecalendar/CompatDateFormatter.kt
@@ -6,13 +6,13 @@ import com.github.pelmenstar1.rangecalendar.utils.getLocaleCompat
 import java.text.FieldPosition
 import java.text.SimpleDateFormat
 import java.util.Date
+import java.util.Locale
 
 internal class CompatDateFormatter(private val context: Context, private val pattern: String) {
     // If API >= 24, the type should be android.icu.text.SimpleDateFormat,
     // otherwise java.text.SimpleDateFormat.
     private var dateFormatter: Any? = null
 
-    // Used in setInfoViewYearMonth.
     private val calendarOrDate: Any = if (Build.VERSION.SDK_INT >= 24) {
         android.icu.util.Calendar.getInstance()
     } else {
@@ -22,28 +22,26 @@ internal class CompatDateFormatter(private val context: Context, private val pat
     private val stringBuffer = StringBuffer(32)
 
     init {
-        refreshFormatter()
+        refreshFormatter(context.getLocaleCompat())
     }
 
-    private fun refreshFormatter() {
-        val locale = context.getLocaleCompat()
-
+    private fun refreshFormatter(currentLocale: Locale) {
         // Find the best format if we can
         val bestFormat = if (Build.VERSION.SDK_INT >= 18) {
-            android.text.format.DateFormat.getBestDateTimePattern(locale, pattern)
+            android.text.format.DateFormat.getBestDateTimePattern(currentLocale, pattern)
         } else {
             pattern
         }
 
         dateFormatter = if (Build.VERSION.SDK_INT >= 24) {
-            android.icu.text.SimpleDateFormat(bestFormat, locale)
+            android.icu.text.SimpleDateFormat(bestFormat, currentLocale)
         } else {
-            SimpleDateFormat(bestFormat, locale)
+            SimpleDateFormat(bestFormat, currentLocale)
         }
     }
 
-    fun onLocaleChanged() {
-        refreshFormatter()
+    fun onLocaleChanged(newLocale: Locale) {
+        refreshFormatter(newLocale)
     }
 
     fun format(date: PackedDate): String {

--- a/library/src/main/java/com/github/pelmenstar1/rangecalendar/RangeCalendarConfigObserver.kt
+++ b/library/src/main/java/com/github/pelmenstar1/rangecalendar/RangeCalendarConfigObserver.kt
@@ -113,25 +113,29 @@ class RangeCalendarConfigObserver(private val calendarView: RangeCalendarView) {
         }
     }
 
+    internal fun onBroadcastReceived(intent: Intent) {
+        when(intent.action) {
+            Intent.ACTION_TIMEZONE_CHANGED -> {
+                if (observeTimeZoneChanges) {
+                    val tzId = if (Build.VERSION.SDK_INT >= 30) {
+                        intent.getStringExtra(Intent.EXTRA_TIMEZONE)
+                    } else null
+
+                    calendarView.timeZone = tzId?.let(TimeZone::getTimeZone) ?: TimeZone.getDefault()
+                }
+            }
+            Intent.ACTION_DATE_CHANGED -> {
+                if (observeDateChanges) {
+                    calendarView.notifyTodayChanged()
+                }
+            }
+        }
+    }
+
     private fun createBroadcastReceiver(): BroadcastReceiver {
         return object : BroadcastReceiver() {
             override fun onReceive(context: Context, intent: Intent) {
-                when(intent.action) {
-                    Intent.ACTION_TIMEZONE_CHANGED -> {
-                        if (observeTimeZoneChanges) {
-                            val tzId = if (Build.VERSION.SDK_INT >= 30) {
-                                intent.getStringExtra(Intent.EXTRA_TIMEZONE)
-                            } else null
-
-                            calendarView.timeZone = tzId?.let(TimeZone::getTimeZone) ?: TimeZone.getDefault()
-                        }
-                    }
-                    Intent.ACTION_DATE_CHANGED -> {
-                        if (observeDateChanges) {
-                            calendarView.notifyTodayChanged()
-                        }
-                    }
-                }
+                onBroadcastReceived(intent)
             }
         }
     }

--- a/library/src/main/java/com/github/pelmenstar1/rangecalendar/RangeCalendarConfigObserver.kt
+++ b/library/src/main/java/com/github/pelmenstar1/rangecalendar/RangeCalendarConfigObserver.kt
@@ -1,0 +1,138 @@
+package com.github.pelmenstar1.rangecalendar
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.Build
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleObserver
+import com.github.pelmenstar1.rangecalendar.utils.getLazyValue
+import java.util.TimeZone
+
+/**
+ * Responsible for observing the changes of some properties (like time zone, date). This is done via [BroadcastReceiver].
+ * The specified [calendarView] is notified about these changes.
+ *
+ * The observer is not enabled by default, it should be done manually through [register]. As the class is based on [BroadcastReceiver],
+ * the observer should also be unregistered (via [unregister]) when appropriate.
+ * To simplify this process, [setLifecycle] can be used, that will unregister the observer when [Lifecycle.Event.ON_DESTROY] in the lifecycle.
+ *
+ * To partially disable some notifications about changes to [calendarView], [observeDateChanges] and [observeTimeZoneChanges] can be used.
+ * Note that, setting them all to true won't register the observer. Alike to setting them all to false, it won't unregister the observer.
+ */
+class RangeCalendarConfigObserver(private val context: Context, private val calendarView: RangeCalendarView) {
+    private var lifecycle: Lifecycle? = null
+    private var lifecycleObserver: LifecycleObserver? = null
+
+    // Expected to be null when it's not registered.
+    private var broadcastReceiver: BroadcastReceiver? = null
+
+    /**
+     * Gets or sets whether specified [RangeCalendarView] should be notified about current date changes. By default, it's `true`.
+     *
+     * Setting this property won't trigger the observer to be registered or unregistered, it should be done manually via [register]/[unregister].
+     */
+    var observeDateChanges: Boolean = true
+
+    /**
+     * Gets or sets whether specified [RangeCalendarView] should be notified about default time zone changes. By default, it's `true`.
+     *
+     * Setting this property won't trigger the observer to be registered or unregistered, it should be done manually via [register]/[unregister].
+     */
+    var observeTimeZoneChanges: Boolean = true
+
+    /**
+     * Sets [Lifecycle] instance. The specified [RangeCalendarView] is expected to have same lifecycle duration
+     * as the specified one.
+     *
+     * The observer will be unregistered on [Lifecycle.Event.ON_DESTROY] event in the lifecycle.
+     */
+    fun setLifecycle(value: Lifecycle?) {
+        // Remove observer from old lifecycle.
+        removeLifecycleObserverFromLifecycle()
+
+        lifecycle = value
+
+        value?.also {
+            it.addObserver(getLifecycleObserver())
+        }
+    }
+
+    /**
+     * Registers the observer. This will create and register [BroadcastReceiver]. The method does nothing if the observer
+     * is already registered.
+     */
+    fun register() {
+        if (broadcastReceiver != null) {
+            return
+        }
+
+        val receiver = createBroadcastReceiver()
+        context.registerReceiver(receiver, IntentFilter().apply {
+            addAction(Intent.ACTION_DATE_CHANGED)
+            addAction(Intent.ACTION_TIMEZONE_CHANGED)
+        })
+
+        broadcastReceiver = receiver
+    }
+
+    /**
+     * Unregister the observer. This will unregister current [BroadcastReceiver]. The method does nothing if the observer
+     * is not registered.
+     */
+    fun unregister() {
+        broadcastReceiver?.let {
+            context.unregisterReceiver(it)
+
+            broadcastReceiver = null
+        }
+    }
+
+    private fun getLifecycleObserver(): LifecycleObserver {
+        return getLazyValue(lifecycleObserver, ::createLifecycleObserver) { lifecycleObserver = it }
+    }
+
+    private fun createLifecycleObserver(): LifecycleObserver {
+        return LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_DESTROY) {
+                unregister()
+
+                removeLifecycleObserverFromLifecycle()
+            }
+        }
+    }
+
+    private fun removeLifecycleObserverFromLifecycle() {
+        lifecycleObserver?.also {
+            // Lifecycle can't be null if observer is not null.
+            lifecycle!!.removeObserver(it)
+
+            lifecycleObserver = null
+        }
+    }
+
+    private fun createBroadcastReceiver(): BroadcastReceiver {
+        return object : BroadcastReceiver() {
+            override fun onReceive(context: Context, intent: Intent) {
+                when(intent.action) {
+                    Intent.ACTION_TIMEZONE_CHANGED -> {
+                        if (observeTimeZoneChanges) {
+                            val tzId = if (Build.VERSION.SDK_INT >= 30) {
+                                intent.getStringExtra(Intent.EXTRA_TIMEZONE)
+                            } else null
+
+                            calendarView.timeZone = tzId?.let(TimeZone::getTimeZone) ?: TimeZone.getDefault()
+                        }
+                    }
+                    Intent.ACTION_DATE_CHANGED -> {
+                        if (observeDateChanges) {
+                            calendarView.notifyTodayChanged()
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/library/src/main/java/com/github/pelmenstar1/rangecalendar/RangeCalendarConfigObserver.kt
+++ b/library/src/main/java/com/github/pelmenstar1/rangecalendar/RangeCalendarConfigObserver.kt
@@ -22,7 +22,7 @@ import java.util.TimeZone
  * To partially disable some notifications about changes to [calendarView], [observeDateChanges] and [observeTimeZoneChanges] can be used.
  * Note that, setting them all to true won't register the observer. Alike to setting them all to false, it won't unregister the observer.
  */
-class RangeCalendarConfigObserver(private val context: Context, private val calendarView: RangeCalendarView) {
+class RangeCalendarConfigObserver(private val calendarView: RangeCalendarView) {
     private var lifecycle: Lifecycle? = null
     private var lifecycleObserver: LifecycleObserver? = null
 
@@ -70,7 +70,7 @@ class RangeCalendarConfigObserver(private val context: Context, private val cale
         }
 
         val receiver = createBroadcastReceiver()
-        context.registerReceiver(receiver, IntentFilter().apply {
+        calendarView.context.registerReceiver(receiver, IntentFilter().apply {
             addAction(Intent.ACTION_DATE_CHANGED)
             addAction(Intent.ACTION_TIMEZONE_CHANGED)
         })
@@ -84,7 +84,7 @@ class RangeCalendarConfigObserver(private val context: Context, private val cale
      */
     fun unregister() {
         broadcastReceiver?.let {
-            context.unregisterReceiver(it)
+            calendarView.context.unregisterReceiver(it)
 
             broadcastReceiver = null
         }

--- a/library/src/main/java/com/github/pelmenstar1/rangecalendar/RangeCalendarPagerAdapter.kt
+++ b/library/src/main/java/com/github/pelmenstar1/rangecalendar/RangeCalendarPagerAdapter.kt
@@ -154,7 +154,9 @@ internal class RangeCalendarPagerAdapter(
     // and this can lead to bugs when we mutate the wrong page.
     var selectionYm = YearMonth(0)
 
-    private var today = PackedDate(0)
+    // used in tests
+    internal var today = PackedDate(0)
+
     private val calendarInfo = CalendarInfo()
     private val styleData = IntArray(20)
     private val styleObjData = arrayOfNulls<Any>(7)

--- a/library/src/main/java/com/github/pelmenstar1/rangecalendar/RangeCalendarView.kt
+++ b/library/src/main/java/com/github/pelmenstar1/rangecalendar/RangeCalendarView.kt
@@ -5,6 +5,7 @@ import android.animation.AnimatorListenerAdapter
 import android.animation.TimeInterpolator
 import android.animation.ValueAnimator
 import android.content.Context
+import android.content.res.Configuration
 import android.content.res.TypedArray
 import android.graphics.Rect
 import android.os.Build
@@ -355,8 +356,6 @@ class RangeCalendarView @JvmOverloads constructor(
     private val hPadding: Int
     private val topContainerMarginBottom: Int
 
-    private val dateFormatter: CompatDateFormatter
-
     private var _selectionView: View? = null
     private var svAnimator: ValueAnimator? = null
 
@@ -373,7 +372,9 @@ class RangeCalendarView @JvmOverloads constructor(
     private val prevIcon: MoveButtonDrawable
     private val nextIcon: MoveButtonDrawable
 
+    private val dateFormatter: CompatDateFormatter
     private var isFirstDaySunday = false
+    private var currentLocale: Locale? = null
 
     private var nextMonthDescription: CharSequence
     private var clearSelectionDescription: CharSequence
@@ -696,8 +697,16 @@ class RangeCalendarView @JvmOverloads constructor(
 
     private fun initLocaleDependentValues() {
         val locale = context.getLocaleCompat()
+        currentLocale = locale
 
         refreshIsFirstDaySunday(locale)
+    }
+
+    private fun refreshLocaleDependentValues(newLocale: Locale) {
+        currentLocale = newLocale
+
+        dateFormatter.onLocaleChanged(newLocale)
+        refreshIsFirstDaySunday(newLocale)
     }
 
     private fun refreshIsFirstDaySunday(locale: Locale) {
@@ -711,6 +720,15 @@ class RangeCalendarView @JvmOverloads constructor(
      */
     fun notifyTodayChanged() {
         adapter.setToday(PackedDate.today(_timeZone))
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+
+        val newLocale = newConfig.getLocaleCompat()
+        if (currentLocale != newLocale) {
+            refreshLocaleDependentValues(newLocale)
+        }
     }
 
     override fun onSaveInstanceState(): Parcelable {

--- a/library/src/main/java/com/github/pelmenstar1/rangecalendar/RangeCalendarView.kt
+++ b/library/src/main/java/com/github/pelmenstar1/rangecalendar/RangeCalendarView.kt
@@ -345,7 +345,9 @@ class RangeCalendarView @JvmOverloads constructor(
 
     private var infoViewYm = YearMonth(0)
     private var currentCalendarYm = YearMonth(0)
-    private val adapter: RangeCalendarPagerAdapter
+
+    @JvmField // used in tests
+    internal val adapter: RangeCalendarPagerAdapter
 
     private var allowedSelectionTypesObj: AllowedSelectionTypes? = null
 

--- a/library/src/main/java/com/github/pelmenstar1/rangecalendar/utils/LocaleUtils.kt
+++ b/library/src/main/java/com/github/pelmenstar1/rangecalendar/utils/LocaleUtils.kt
@@ -1,16 +1,19 @@
 package com.github.pelmenstar1.rangecalendar.utils
 
 import android.content.Context
+import android.content.res.Configuration
 import android.os.Build
 import java.util.*
 
-internal fun Context.getLocaleCompat(): Locale {
-    val config = resources.configuration
-
+internal fun Configuration.getLocaleCompat(): Locale {
     return if (Build.VERSION.SDK_INT >= 24) {
-        config.locales[0]
+        locales[0]
     } else {
         @Suppress("DEPRECATION")
-        config.locale
+        locale
     }
+}
+
+internal fun Context.getLocaleCompat(): Locale {
+    return resources.configuration.getLocaleCompat()
 }


### PR DESCRIPTION
- Adds RangeCalendarConfigObserver that handles date and timezone observations.
- Now, timezone observation is not enabled by default
- Also makes RangeCalendarView react to locale changes.