### PR TITLE
Move logic of managing calendar's style out of RangeCalendarPagerAdapter

### DIFF
--- a/library/src/main/java/com/github/pelmenstar1/rangecalendar/PackedTypes.kt
+++ b/library/src/main/java/com/github/pelmenstar1/rangecalendar/PackedTypes.kt
@@ -85,7 +85,7 @@ internal value class PackedSizeArray(val array: LongArray) {
 
 internal inline fun PackedInt(value: Float) = PackedInt(value.toBits())
 internal inline fun PackedInt(value: Boolean) = PackedInt(if(value) 1 else 0)
-internal inline fun <T : Enum<T>> PackedInt(value: T) = PackedInt(value.ordinal)
+internal inline fun PackedInt(value: Enum<*>) = PackedInt(value.ordinal)
 
 @JvmInline
 internal value class PackedInt(val value: Int) {

--- a/library/src/main/java/com/github/pelmenstar1/rangecalendar/RangeCalendarGridView.kt
+++ b/library/src/main/java/com/github/pelmenstar1/rangecalendar/RangeCalendarGridView.kt
@@ -33,7 +33,11 @@ import kotlin.math.min
 
 // It will never be XML layout, so there's no need to match conventions
 @SuppressLint("ViewConstructor")
-internal class RangeCalendarGridView(context: Context, val cr: CalendarResources) : View(context) {
+internal class RangeCalendarGridView(
+    context: Context,
+    val cr: CalendarResources,
+    val style: RangeCalendarStyleData
+) : View(context) {
     interface OnSelectionListener {
         fun onSelectionCleared()
         fun onSelection(range: CellRange)
@@ -107,8 +111,8 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
         }
 
         private fun getDayDescriptionForIndex(index: Int): CharSequence {
-            val provider = grid.cellAccessibilityInfoProvider
-                ?: throw RuntimeException("cellAccessibilityInfoProvider should not be null")
+            val provider =
+                grid.style.getObject<RangeCalendarCellAccessibilityInfoProvider> { CELL_ACCESSIBILITY_INFO_PROVIDER }
 
             val (monthStart, monthEnd) = grid.inMonthRange
 
@@ -151,10 +155,10 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
     private class CellMeasureManagerImpl(private val view: RangeCalendarGridView) :
         CellMeasureManager {
         override val cellWidth: Float
-            get() = view.cellWidth
+            get() = view.cellWidth()
 
         override val cellHeight: Float
-            get() = view.cellHeight
+            get() = view.cellHeight()
 
         override val roundRadius: Float
             get() = view.cellRoundRadius()
@@ -171,29 +175,10 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
 
     val cells = ByteArray(42)
 
-    private var cellWidth: Float = cr.cellSize
-    private var cellHeight: Float = cr.cellSize
-
-    // The cell is circle by default and to achieve it with any possible cell size,
-    // we should take greatest round radius possible, that's why it's positive inf.
-    //
-    // But when infinity is passed as round radius, round radius is changed to 0 somewhere inside the Android
-    // and round rect becomes rect. So, when rrRadius is used, it needs to be resolved to get rid of infinities.
-    //
-    // There's method for that: cellRoundRadius()
-    private var rrRadius: Float = Float.POSITIVE_INFINITY
-
     private val dayNumberPaint: Paint
     private val weekdayPaint: Paint
     private val selectionPaint: Paint
     private val cellHoverPaint: Paint
-
-    private var inMonthTextColor: Int
-    private var outMonthTextColor: Int
-    private var disabledCellTextColor: Int
-    private var todayCellTextColor: Int
-    private var hoverCellBgColor: Int
-    private var hoverOnSelectionBgColor: Int
 
     private var lastTouchTime: Long = -1
     private var lastTouchCell = Cell.Undefined
@@ -216,10 +201,7 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
 
     private var selectionManager: SelectionManager = DefaultSelectionManager()
     private var selectionRenderer = selectionManager.renderer
-    private var selectionRenderOptions: SelectionRenderOptions
-
-    private var selectionFill: Fill
-    private var selectionFillGradientBoundsType = SelectionFillGradientBoundsType.GRID
+    private var selectionRenderOptions: SelectionRenderOptions? = null
 
     private val cellMeasureManager = CellMeasureManagerImpl(this)
 
@@ -232,26 +214,14 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
     private var onAnimationEnd: (() -> Unit)? = null
     private var animationHandler: (() -> Unit)? = null
 
-    private val touchHelper: TouchHelper
+    private val touchHelper = TouchHelper(this)
 
     private val weekdayRow: WeekdayRow
 
     private var isDayNumberMeasurementsDirty = false
     private var dayNumberSizes = cr.defaultDayNumberSizes
 
-    var clickOnCellSelectionBehavior = ClickOnCellSelectionBehavior.NONE
-    var commonAnimationDuration = DEFAULT_COMMON_ANIM_DURATION
-    var hoverAnimationDuration = DEFAULT_HOVER_ANIM_DURATION
-    var commonAnimationInterpolator: TimeInterpolator = LINEAR_INTERPOLATOR
-    var hoverAnimationInterpolator: TimeInterpolator = LINEAR_INTERPOLATOR
-
-    private var cellAnimationType = CellAnimationType.ALPHA
-
     private val vibrator = VibratorCompat(context)
-
-    var vibrateOnSelectingCustomRange = true
-
-    private var showAdjacentMonths = true
 
     internal var decorations: DecorGroupedList? = null
     private var decorRegion = PackedIntRange.Undefined
@@ -259,7 +229,6 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
     private val decorVisualStates = LazyCellDataArray<CellDecor.VisualState>()
     private val decorLayoutOptionsArray = LazyCellDataArray<DecorLayoutOptions>()
     private val cellInfo = CellInfo()
-    private var decorDefaultLayoutOptions: DecorLayoutOptions? = null
 
     private var decorAnimFractionInterpolator: DecorAnimationFractionInterpolator? = null
     private var decorAnimatedCell = Cell.Undefined
@@ -269,47 +238,17 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
 
     private val pressTimeoutHandler = PressTimeoutHandler(this)
 
-    private var cellAccessibilityInfoProvider: RangeCalendarCellAccessibilityInfoProvider? = null
-
     init {
-        val defTextColor = cr.textColor
-        val colorPrimary = cr.colorPrimary
-        val dayNumberTextSize = cr.dayNumberTextSize
-
-        touchHelper = TouchHelper(this)
         ViewCompat.setAccessibilityDelegate(this, touchHelper)
 
-        inMonthTextColor = defTextColor
-        outMonthTextColor = cr.outMonthTextColor
-        disabledCellTextColor = cr.disabledTextColor
-        todayCellTextColor = colorPrimary
-        hoverCellBgColor = cr.hoverColor
-        hoverOnSelectionBgColor = cr.colorPrimaryDark
-
-        selectionFill = Fill.solid(colorPrimary)
         background = null
-
-        selectionRenderOptions = SelectionRenderOptions(
-            selectionFill,
-            SelectionFillGradientBoundsType.GRID,
-            cr.cellSize * 0.5f,
-            CellAnimationType.ALPHA
-        )
 
         selectionPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
             style = Paint.Style.FILL
         }
 
-        dayNumberPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-            textSize = dayNumberTextSize
-            color = defTextColor
-        }
-
-        weekdayPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-            textSize = cr.weekdayTextSize
-            typeface = Typeface.DEFAULT_BOLD
-            color = defTextColor
-        }
+        dayNumberPaint = Paint(Paint.ANTI_ALIAS_FLAG)
+        weekdayPaint = Paint(Paint.ANTI_ALIAS_FLAG)
 
         cellHoverPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
             style = Paint.Style.FILL
@@ -318,32 +257,37 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
         weekdayRow = WeekdayRow(cr.defaultWeekdayData, weekdayPaint)
     }
 
-    private inline fun updateUIState(block: () -> Unit) =
-        updateUIState(condition = true, block)
+    private fun rrRadius(): Float = style.getFloat { CELL_ROUND_RADIUS }
+    private fun cellWidth(): Float = style.getFloat { CELL_WIDTH }
+    private fun cellHeight(): Float = style.getFloat { CELL_HEIGHT }
 
-    private inline fun <T> updateUIState(oldValue: T, newValue: T, block: () -> Unit) =
-        updateUIState(oldValue != newValue, block)
+    private fun selectionFill() = style.getObject<Fill> { SELECTION_FILL }
+    private fun selectionFillGradientBoundsType() =
+        SelectionFillGradientBoundsType.ofOrdinal(style.getInt { SELECTION_FILL_GRADIENT_BOUNDS_TYPE })
 
-    private inline fun updateUIState(oldValue: Float, newValue: Float, block: () -> Unit) =
-        updateUIState(oldValue != newValue, block)
+    private fun clickOnCellSelectionBehavior() =
+        ClickOnCellSelectionBehavior.ofOrdinal(style.getInt { CLICK_ON_CELL_SELECTION_BEHAVIOR })
 
-    private inline fun updateUIState(oldValue: Int, newValue: Int, block: () -> Unit) =
-        updateUIState(oldValue != newValue, block)
+    private fun cellAnimationType() =
+        CellAnimationType.ofOrdinal(style.getInt { CELL_ANIMATION_TYPE })
 
-    private inline fun updateUIState(condition: Boolean, block: () -> Unit) {
-        if (condition) {
-            block()
+    private fun showAdjacentMonths() = style.getBoolean { SHOW_ADJACENT_MONTHS }
+    private fun vibrateOnSelectingRange() = style.getBoolean { VIBRATE_ON_SELECTING_RANGE }
 
-            invalidate()
-        }
-    }
+    private fun commonAnimationDuration() = style.getInt { COMMON_ANIMATION_DURATION }
+    private fun hoverAnimationDuration() = style.getInt { HOVER_ANIMATION_DURATION }
+
+    private fun commonAnimationInterpolator() = style.getObject<TimeInterpolator> { COMMON_ANIMATION_INTERPOLATOR }
+    private fun hoverAnimationInterpolator() = style.getObject<TimeInterpolator> { HOVER_ANIMATION_INTERPOLATOR }
+
+    private fun decorDefaultLayoutOptions() = style.getObject<DecorLayoutOptions> { DECOR_DEFAULT_LAYOUT_OPTIONS }
 
     private fun updateSelectionRenderOptions() {
         selectionRenderOptions = SelectionRenderOptions(
-            selectionFill,
-            selectionFillGradientBoundsType,
+            selectionFill(),
+            selectionFillGradientBoundsType(),
             cellRoundRadius(),
-            cellAnimationType
+            cellAnimationType()
         )
 
         invalidate()
@@ -355,22 +299,52 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
         invalidate()
     }
 
-    fun setSelectionFill(fill: Fill) = updateUIState {
-        selectionFill = fill
-
-        updateGradientBoundsIfNeeded()
-        updateSelectionRenderOptions()
+    fun onStylePropertyChanged(propIndex: Int) {
+        if (RangeCalendarStyleData.isObjectProperty(propIndex)) {
+            onStylePropertyObjectChanged(propIndex)
+        } else {
+            onStylePropertyIntChanged(propIndex)
+        }
     }
 
-    fun setSelectionFillGradientBoundsType(value: SelectionFillGradientBoundsType) =
-        updateUIState(selectionFillGradientBoundsType, value) {
-            selectionFillGradientBoundsType = value
+    private fun onStylePropertyIntChanged(propIndex: Int) {
+        val data = style.getPackedInt(propIndex)
 
-            updateGradientBoundsIfNeeded()
-            updateSelectionRenderOptions()
+        with(RangeCalendarStyleData.Companion) {
+            when (propIndex) {
+                DAY_NUMBER_TEXT_SIZE -> onDayNumberTextSizeChanged(data.float())
+                WEEKDAY_TEXT_SIZE -> onWeekdayTextSizeChanged(data.float())
+                CELL_WIDTH, CELL_HEIGHT -> onCellSizeComponentChanged()
+                WEEKDAY_TYPE -> onWeekdayTypeChanged(data.enum(WeekdayType::ofOrdinal))
+                SELECTION_FILL_GRADIENT_BOUNDS_TYPE -> onSelectionFillOrGradientBoundsTypeChanged()
+                CELL_ANIMATION_TYPE -> onCellAnimationTypeChanged()
+                SHOW_ADJACENT_MONTHS -> onShowAdjacentMonthsChanged()
+            }
         }
+    }
 
-    fun setSelectionManager(manager: SelectionManager?) = updateUIState {
+    private fun onStylePropertyObjectChanged(propIndex: Int) {
+        val data = PackedObject(style.getObject(propIndex))
+
+        with(RangeCalendarStyleData.Companion) {
+            when (propIndex) {
+                DECOR_DEFAULT_LAYOUT_OPTIONS -> onDecorationDefaultLayoutOptionsChanged()
+                SELECTION_FILL -> onSelectionFillOrGradientBoundsTypeChanged()
+                SELECTION_MANAGER -> onSelectionManagerChanged(data.value())
+                CELL_ACCESSIBILITY_INFO_PROVIDER -> onCellAccessibilityInfoProviderChanged()
+                WEEKDAY_TYPEFACE -> onWeekdayTypefaceChanged(data.value())
+                WEEKDAYS -> onWeekdaysChanged(data.value())
+            }
+        }
+    }
+
+    private fun onSelectionFillOrGradientBoundsTypeChanged() {
+        updateGradientBoundsIfNeeded()
+        updateSelectionRenderOptions()
+        invalidate()
+    }
+
+    private fun onSelectionManagerChanged(manager: SelectionManager?) {
         val resolvedManager = manager ?: DefaultSelectionManager()
 
         // DefaultSelectionManager has no options and preferences which means re-setting it has no effect.
@@ -388,6 +362,8 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
 
         selectionManager = resolvedManager
         selectionRenderer = resolvedManager.renderer
+
+        invalidate()
     }
 
     private fun SelectionManager.setStateOrNone(state: SelectionState) {
@@ -401,79 +377,43 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
         }
     }
 
-    fun setCellAnimationType(type: CellAnimationType) = updateUIState(cellAnimationType, type) {
-        cellAnimationType = type
-
+    private fun onCellAnimationTypeChanged() {
         updateSelectionRenderOptions()
     }
 
-    fun setDayNumberTextSize(size: Float) = updateUIState(dayNumberPaint.textSize, size) {
-        dayNumberPaint.textSize = size
+    private fun onDayNumberTextSizeChanged(newSize: Float) {
+        dayNumberPaint.textSize = newSize
 
-        if (size != cr.dayNumberTextSize) {
+        if (newSize != cr.dayNumberTextSize) {
             isDayNumberMeasurementsDirty = true
         }
 
         refreshAllDecorVisualStates()
     }
 
-    fun setWeekdayTextSize(size: Float) = updateUIState(weekdayPaint.textSize, size) {
-        weekdayPaint.textSize = size
+    private fun onWeekdayTextSizeChanged(newSize: Float) {
+        weekdayPaint.textSize = newSize
         weekdayRow.onMeasurementsChanged()
 
         onGridTopChanged()
     }
 
-    fun setWeekdayTypeface(typeface: Typeface?) = updateUIState(weekdayPaint.typeface, typeface) {
+    private fun onWeekdayTypefaceChanged(typeface: Typeface?) {
         weekdayPaint.typeface = typeface
         weekdayRow.onMeasurementsChanged()
 
         onGridTopChanged()
     }
 
-    fun setCustomWeekdays(weekdays: Array<out String>?) = updateUIState(weekdayRow.weekdays, weekdays) {
+    private fun onWeekdaysChanged(weekdays: Array<out String>?) {
         weekdayRow.weekdays = weekdays
 
         onGridChanged()
     }
 
-    fun setInMonthTextColor(color: Int) = updateUIState(inMonthTextColor, color) {
-        inMonthTextColor = color
-    }
-
-    fun setOutMonthTextColor(color: Int) = updateUIState(outMonthTextColor, color) {
-        outMonthTextColor = color
-    }
-
-    fun setDisabledCellTextColor(color: Int) = updateUIState(disabledCellTextColor, color) {
-        disabledCellTextColor = color
-    }
-
-    fun setTodayCellColor(color: Int) = updateUIState(todayCellTextColor, color) {
-        todayCellTextColor = color
-    }
-
-    fun setHoverColor(color: Int) = updateUIState(hoverCellBgColor, color) {
-        hoverCellBgColor = color
-    }
-
-    fun setHoverOnSelectionColor(color: Int) = updateUIState(hoverOnSelectionBgColor, color) {
-        hoverCellBgColor = color
-    }
-
-    fun setWeekdayTextColor(color: Int) = updateUIState(weekdayPaint.color, color) {
+    private fun onWeekdayTextColorChanged(color: Int) {
         weekdayPaint.color = color
-    }
-
-    fun setCellSize(size: Float) {
-        require(size > 0f) { "size <= 0" }
-
-        if (cellWidth != size || cellHeight != size) {
-            cellWidth = size
-            cellHeight = size
-
-            onCellSizeComponentChanged()
-        }
+        invalidate()
     }
 
     private inline fun setCellWidthHeightInternal(
@@ -488,7 +428,7 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
         }
     }
 
-    private fun onCellSizeComponentChanged() {
+    fun onCellSizeComponentChanged() {
         refreshAllDecorVisualStates()
         updateSelectionStateConfiguration()
 
@@ -496,25 +436,33 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
         requestLayout()
     }
 
-    fun setCellWidth(value: Float) {
-        require(value > 0f) { "width <= 0" }
-
-        setCellWidthHeightInternal(value, cellWidth) { cellWidth = it }
-    }
-
-    fun setCellHeight(value: Float) {
-        require(value > 0f) { "height <= 0" }
-
-        setCellWidthHeightInternal(value, cellHeight) { cellHeight = it }
-    }
-
-    fun setCellRoundRadius(value: Float) = updateUIState(rrRadius, value) {
-        require(value >= 0f) { "ratio < 0" }
-
-        rrRadius = value
-
+    fun onCellRoundRadiusChanged()  {
         refreshAllDecorVisualStates()
         updateSelectionRenderOptions()
+
+        invalidate()
+    }
+
+    private fun onWeekdayTypeChanged(_type: WeekdayType) {
+        // There is no narrow weekdays before API < 24, so we need to resolve it
+        val type = _type.resolved()
+
+        if (weekdayRow.type != type) {
+            weekdayRow.type = type
+
+            onGridTopChanged()
+            invalidate()
+        }
+    }
+
+    private fun onShowAdjacentMonthsChanged() {
+        // showAdjacentMonths directly affects on the selection range, so we need to update it.
+        updateSelectionRange()
+    }
+
+    private fun onCellAccessibilityInfoProviderChanged() {
+        // Some accessibility-related properties might be changed.
+        touchHelper.invalidateRoot()
     }
 
     fun setInMonthRange(range: CellRange) {
@@ -529,40 +477,18 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
         updateSelectionRange()
     }
 
-    fun setWeekdayType(_type: WeekdayType) {
-        // There is no narrow weekdays before API < 24, so we need to resolve it
-        val type = _type.resolved()
+    fun setTodayCell(cell: Cell) {
+        val old = todayCell
+        todayCell = cell
 
-        if (weekdayRow.type != type) {
-            weekdayRow.type = type
-
-            onGridTopChanged()
+        if (old != cell) {
             invalidate()
         }
     }
 
-    fun setTodayCell(cell: Cell) = updateUIState(todayCell != cell) {
-        todayCell = cell
-        invalidate()
-    }
-
-    fun setShowAdjacentMonths(value: Boolean) = updateUIState(showAdjacentMonths != value) {
-        showAdjacentMonths = value
-
-        // showAdjacentMonths directly affects on the selection range, so we need to update it.
-        updateSelectionRange()
-    }
-
-    fun setCellAccessibilityInfoProvider(value: RangeCalendarCellAccessibilityInfoProvider) {
-        cellAccessibilityInfoProvider = value
-
-        // Some accessibility-related properties might be changed.
-        touchHelper.invalidateRoot()
-    }
-
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
-        val preferredWidth = ceilToInt(cellWidth * 7)
-        val preferredHeight = ceilToInt(gridTop() + (cellHeight * 6))
+        val preferredWidth = ceilToInt(cellWidth() * 7)
+        val preferredHeight = ceilToInt(gridTop() + (cellHeight() * 6))
 
         setMeasuredDimension(
             resolveSize(preferredWidth, widthMeasureSpec),
@@ -576,10 +502,10 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
     }
 
     private fun updateGradientBoundsIfNeeded() {
-        if (selectionFillGradientBoundsType == SelectionFillGradientBoundsType.GRID) {
+        if (selectionFillGradientBoundsType() == SelectionFillGradientBoundsType.GRID) {
             val hPadding = cr.hPadding
 
-            selectionFill.setBounds(
+            selectionFill().setBounds(
                 hPadding, gridTop(), width - hPadding, height.toFloat()
             )
         }
@@ -738,7 +664,7 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
             val top = getCellTop(start)
             val right = getCellRight(end)
 
-            r.set(left.toInt(), top.toInt(), ceilToInt(right), ceilToInt(top + cellHeight))
+            r.set(left.toInt(), top.toInt(), ceilToInt(right), ceilToInt(top + cellHeight()))
         } else {
             super.getFocusedRect(r)
         }
@@ -788,7 +714,7 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
         // We don't do gate validation if the request come from user and it's the same selection and specified behaviour is CLEAR.
         // That's done because if the gate rejects the request and behaviour is PRESERVE, the cell won't be cleared but
         // it should be.
-        if (isCellSelectionByUser && isSameCellSelection && clickOnCellSelectionBehavior == ClickOnCellSelectionBehavior.CLEAR) {
+        if (isCellSelectionByUser && isSameCellSelection && clickOnCellSelectionBehavior() == ClickOnCellSelectionBehavior.CLEAR) {
             clearSelection(fireEvent = true, doAnimation = true)
             return
         }
@@ -807,7 +733,7 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
         clearHoverCellWithAnimation()
 
         var intersection = range.intersectionWith(enabledCellRange)
-        if (!showAdjacentMonths) {
+        if (!showAdjacentMonths()) {
             intersection = intersection.intersectionWith(inMonthRange)
         }
 
@@ -832,7 +758,7 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
             clearHoverCellWithAnimation()
         }
 
-        if (vibrateOnSelectingCustomRange && isUserStartSelection) {
+        if (vibrateOnSelectingRange() && isUserStartSelection) {
             vibrateOnUserSelection()
         }
 
@@ -858,7 +784,15 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
 
         val handler = getLazyValue(
             selectionTransitionHandler,
-            { { controller.handleTransition(selectionTransitiveState!!, cellMeasureManager, animFraction) } },
+            {
+                {
+                    controller.handleTransition(
+                        selectionTransitiveState!!,
+                        cellMeasureManager,
+                        animFraction
+                    )
+                }
+            },
             { selectionTransitionHandler = it }
         )
         val onEnd = getLazyValue(
@@ -871,7 +805,7 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
         endCalendarAnimation()
 
         selectionTransitiveState =
-            selectionManager.createTransition(cellMeasureManager, selectionRenderOptions)
+            selectionManager.createTransition(cellMeasureManager, selectionRenderOptions!!)
 
         startCalendarAnimation(SELECTION_ANIMATION, handler, onEnd)
     }
@@ -928,8 +862,8 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
             return stateHandler.emptyState()
         }
 
-        val cw = cellWidth
-        val ch = cellHeight
+        val cw = cellWidth()
+        val ch = cellHeight()
 
         val halfCellWidth = cw * 0.5f
         val halfCellHeight = ch * 0.5f
@@ -942,7 +876,7 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
             width = cw
             height = ch
             radius = cellRoundRadius()
-            layoutOptions = decorLayoutOptionsArray[cell] ?: decorDefaultLayoutOptions
+            layoutOptions = decorLayoutOptionsArray[cell] ?: decorDefaultLayoutOptions()
 
             setTextBounds(
                 halfCellWidth - halfCellTextWidth,
@@ -971,9 +905,7 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
     }
 
     // Should be called on calendar's decors initialization
-    fun setDecorationDefaultLayoutOptions(options: DecorLayoutOptions?) {
-        decorDefaultLayoutOptions = options
-
+    fun onDecorationDefaultLayoutOptionsChanged() {
         decorVisualStates.forEachNotNull { cell, value ->
             val endState = createDecorVisualState(value.visual().stateHandler(), cell)
 
@@ -1025,14 +957,8 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
         }
     }
 
-    // Common setDecorationLayoutOptions() updates visual states.
-    // Default layout options is set here to avoid double-update of the states.
-    fun onDecorInit(
-        newDecorRegion: PackedIntRange,
-        defaultLayoutOptions: DecorLayoutOptions?
-    ) {
+    fun onDecorInit(newDecorRegion: PackedIntRange) {
         decorRegion = newDecorRegion
-        decorDefaultLayoutOptions = defaultLayoutOptions
 
         val decors = decorations!!
 
@@ -1172,8 +1098,6 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
 
             animator.addListener(object : AnimatorListenerAdapter() {
                 override fun onAnimationEnd(a: Animator) {
-                    //Log.i(TAG, "onAnimationEnd()")
-
                     animType = NO_ANIMATION
                     onAnimationEnd?.invoke()
 
@@ -1185,11 +1109,11 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
         }
 
         if (type and ANIMATION_DATA_MASK == HOVER_ANIMATION) {
-            animator.duration = hoverAnimationDuration.toLong()
-            animator.interpolator = hoverAnimationInterpolator
+            animator.duration = hoverAnimationDuration().toLong()
+            animator.interpolator = hoverAnimationInterpolator()
         } else {
-            animator.duration = commonAnimationDuration.toLong()
-            animator.interpolator = commonAnimationInterpolator
+            animator.duration = commonAnimationDuration().toLong()
+            animator.interpolator = commonAnimationInterpolator()
         }
 
         if ((type and ANIMATION_REVERSE_BIT) != 0) {
@@ -1222,7 +1146,7 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
 
     private fun drawSelection(c: Canvas) {
         val renderer = selectionRenderer
-        val options = selectionRenderOptions
+        val options = selectionRenderOptions!!
 
         if ((animType and ANIMATION_DATA_MASK) == SELECTION_ANIMATION) {
             selectionTransitiveState?.let {
@@ -1248,9 +1172,9 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
             val isOnSelection = selectionManager.currentState.contains(cell)
 
             var color = if (isOnSelection) {
-                hoverOnSelectionBgColor
+                style.getInt { HOVER_ON_SELECTION_COLOR }
             } else {
-                hoverCellBgColor
+                style.getInt { HOVER_COLOR }
             }
 
             if (isHoverAnimation) {
@@ -1260,7 +1184,7 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
             cellHoverPaint.color = color
 
             c.drawRoundRectCompat(
-                left, top, left + cellWidth, top + cellHeight,
+                left, top, left + cellWidth(), top + cellHeight(),
                 cellRoundRadius(), cellHoverPaint
             )
         }
@@ -1269,23 +1193,21 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
     private fun drawCells(c: Canvas) {
         measureDayNumberTextSizesIfNecessary()
 
-        val halfCellHeight = cellHeight * 0.5f
+        val halfCellHeight = cellHeight() * 0.5f
         val startIndex: Int
         val endIndex: Int
 
-        if (showAdjacentMonths) {
+        if (showAdjacentMonths()) {
             startIndex = 0
-            endIndex = 42
+            endIndex = 41
         } else {
             val (start, end) = inMonthRange
 
             startIndex = start.index
-
-            // endIndex is exclusive, inMonthRange.end is inclusive, that's why +1
-            endIndex = end.index + 1
+            endIndex = end.index
         }
 
-        for (i in startIndex until endIndex) {
+        for (i in startIndex .. endIndex) {
             val cell = Cell(i)
 
             val centerX = getCellCenterLeft(cell)
@@ -1329,18 +1251,18 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
 
     private fun drawCell(c: Canvas, centerX: Float, centerY: Float, day: Int, cellType: Int) {
         if (day > 0) {
-            val color = when (cellType and CELL_DATA_MASK) {
-                CELL_SELECTED, CELL_IN_MONTH -> inMonthTextColor
-                CELL_OUT_MONTH -> outMonthTextColor
-                CELL_DISABLED -> disabledCellTextColor
+            val propIndex = when(cellType and CELL_DATA_MASK) {
+                CELL_SELECTED, CELL_IN_MONTH -> RangeCalendarStyleData.IN_MONTH_TEXT_COLOR
+                CELL_OUT_MONTH -> RangeCalendarStyleData.OUT_MONTH_TEXT_COLOR
                 CELL_TODAY -> if ((cellType and CELL_HOVER_BIT) != 0) {
-                    inMonthTextColor
+                    RangeCalendarStyleData.IN_MONTH_TEXT_COLOR
                 } else {
-                    todayCellTextColor
+                    RangeCalendarStyleData.TODAY_TEXT_COLOR
                 }
-
                 else -> throw IllegalArgumentException("type")
             }
+
+            val color = style.getInt(propIndex)
 
             val textSize = getDayNumberSize(day)
 
@@ -1399,13 +1321,16 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
     }
 
     private fun onGridTopChanged() {
+        // Gradient bounds if gradient bounds type is GRID, depends on gridTop()
         updateGradientBoundsIfNeeded()
+
+        // Selection state's internal measurements depend on coordinates of cells that depend on gridTop()
         updateSelectionStateConfiguration()
 
         // Height of the view depends on gridTop()
         requestLayout()
 
-        // y-axis of entries depends on type of weekday, so we need to refresh accessibility info
+        // Y coordinates of cells depend on gridTop(), so we need to refresh accessibility info
         touchHelper.invalidateRoot()
     }
 
@@ -1415,7 +1340,7 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
 
     // It'd be better if cellRoundRadius() returns round radius that isn't greater than half of cell size.
     private fun cellRoundRadius(): Float {
-        return min(rrRadius, min(cellWidth, cellHeight) * 0.5f)
+        return min(rrRadius(), min(cellWidth(), cellHeight()) * 0.5f)
     }
 
     // Width of the view without horizontal paddings (left and right)
@@ -1428,7 +1353,7 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
     }
 
     private fun firstCellLeft(): Float {
-        return cr.hPadding + (columnWidth() - cellWidth) * 0.5f
+        return cr.hPadding + (columnWidth() - cellWidth()) * 0.5f
     }
 
     private fun getCellCenterLeft(cell: Cell): Float {
@@ -1436,15 +1361,15 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
     }
 
     private fun getCellLeft(cell: Cell): Float {
-        return getCellCenterLeft(cell) - cellWidth * 0.5f
+        return getCellCenterLeft(cell) - cellWidth() * 0.5f
     }
 
     private fun getCellRight(cell: Cell): Float {
-        return getCellCenterLeft(cell) + cellWidth * 0.5f
+        return getCellCenterLeft(cell) + cellWidth() * 0.5f
     }
 
     private fun getCellTopByGridY(gridY: Int): Float {
-        return gridTop() + gridY * cellHeight
+        return gridTop() + gridY * cellHeight()
     }
 
     private fun getCellTop(cell: Cell): Float {
@@ -1452,22 +1377,26 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
     }
 
     private fun fillCellBounds(cell: Cell, bounds: Rect) {
-        val left = getCellLeft(cell)
-        val top = getCellTop(cell)
+        val gridY = cell.gridY
+        val halfCw = cellWidth() * 0.5f
+        val ch = cellHeight()
 
-        bounds.set(
-            left.toInt(),
-            top.toInt(),
-            ceilToInt(left + cellWidth),
-            ceilToInt(top + cellHeight)
-        )
+        val centerX = getCellCenterLeft(cell)
+
+        val left = centerX - halfCw
+        val right = centerX + halfCw
+
+        val top = gridTop() + ch * gridY
+        val bottom = top + ch
+
+        bounds.set(left.toInt(), top.toInt(), ceilToInt(right), ceilToInt(bottom))
     }
 
     private fun getCellDistance(cell: Cell): Float {
         val rw = rowWidth()
 
         // First, find a x-axis of the cell but without horizontal padding
-        var distance = (rw / 7f) * (cell.gridX + 0.5f) - cellWidth * 0.5f
+        var distance = (rw / 7f) * (cell.gridX + 0.5f) - cellWidth() * 0.5f
 
         // Add widths of the rows on the way to the cell.
         distance += rw * cell.gridY
@@ -1495,13 +1424,13 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
 
     private fun getCellByPointOnScreen(x: Float, y: Float): Cell {
         val gridX = ((x - cr.hPadding) / columnWidth()).toInt()
-        val gridY = ((y - gridTop()) / cellHeight).toInt()
+        val gridY = ((y - gridTop()) / cellHeight()).toInt()
 
         return Cell(gridY * 7 + gridX)
     }
 
     private fun isSelectableCell(cell: Cell): Boolean {
-        return enabledCellRange.contains(cell) && (showAdjacentMonths || inMonthRange.contains(cell))
+        return enabledCellRange.contains(cell) && (showAdjacentMonths() || inMonthRange.contains(cell))
     }
 
     // Checks whether x in active (touchable) zone
@@ -1526,8 +1455,6 @@ internal class RangeCalendarGridView(context: Context, val cr: CalendarResources
 
         private val ALL_SELECTED = CellRange(0, 42)
 
-        const val DEFAULT_COMMON_ANIM_DURATION = 250
-        const val DEFAULT_HOVER_ANIM_DURATION = 100
         private val HOVER_DELAY = ViewConfiguration.getTapTimeout()
 
         private const val DOUBLE_TOUCH_MAX_MILLIS: Long = 500

--- a/library/src/main/java/com/github/pelmenstar1/rangecalendar/RangeCalendarGridView.kt
+++ b/library/src/main/java/com/github/pelmenstar1/rangecalendar/RangeCalendarGridView.kt
@@ -315,9 +315,11 @@ internal class RangeCalendarGridView(
                 DAY_NUMBER_TEXT_SIZE -> onDayNumberTextSizeChanged(data.float())
                 WEEKDAY_TEXT_SIZE -> onWeekdayTextSizeChanged(data.float())
                 CELL_WIDTH, CELL_HEIGHT -> onCellSizeComponentChanged()
+                CELL_ROUND_RADIUS -> onCellRoundRadiusChanged()
                 WEEKDAY_TYPE -> onWeekdayTypeChanged(data.enum(WeekdayType::ofOrdinal))
                 SELECTION_FILL_GRADIENT_BOUNDS_TYPE -> onSelectionFillOrGradientBoundsTypeChanged()
                 CELL_ANIMATION_TYPE -> onCellAnimationTypeChanged()
+                WEEKDAY_TEXT_COLOR -> onWeekdayTextColorChanged(data.value)
                 SHOW_ADJACENT_MONTHS -> onShowAdjacentMonthsChanged()
             }
         }

--- a/library/src/main/java/com/github/pelmenstar1/rangecalendar/RangeCalendarGridView.kt
+++ b/library/src/main/java/com/github/pelmenstar1/rangecalendar/RangeCalendarGridView.kt
@@ -418,18 +418,6 @@ internal class RangeCalendarGridView(
         invalidate()
     }
 
-    private inline fun setCellWidthHeightInternal(
-        newValue: Float,
-        currentValue: Float,
-        setCurrent: (Float) -> Unit
-    ) {
-        if (currentValue != newValue) {
-            setCurrent(newValue)
-
-            onCellSizeComponentChanged()
-        }
-    }
-
     fun onCellSizeComponentChanged() {
         refreshAllDecorVisualStates()
         updateSelectionStateConfiguration()

--- a/library/src/main/java/com/github/pelmenstar1/rangecalendar/RangeCalendarPagerAdapter.kt
+++ b/library/src/main/java/com/github/pelmenstar1/rangecalendar/RangeCalendarPagerAdapter.kt
@@ -746,11 +746,8 @@ internal class RangeCalendarPagerAdapter(
         gridView.setInMonthRange(gridInfo.inMonthRange)
         updateTodayIndex(gridView, position)
 
-        style.forEachIntStyle { propIndex ->
-            gridView.onStylePropertyChanged(propIndex)
-        }
-
-        style.forEachObjectStyle { propIndex ->
+        // Call onStylePropertyChanged to initialize the view with particular style data.
+        style.forEachProperty { propIndex ->
             gridView.onStylePropertyChanged(propIndex)
         }
 

--- a/library/src/main/java/com/github/pelmenstar1/rangecalendar/RangeCalendarPagerAdapter.kt
+++ b/library/src/main/java/com/github/pelmenstar1/rangecalendar/RangeCalendarPagerAdapter.kt
@@ -122,10 +122,6 @@ internal class RangeCalendarPagerAdapter(
     private var maxDate = PackedDate.MAX_DATE
 
     var selectionRange = CellRange.Invalid
-
-    // We need to save year-month of selection despite the fact we can compute it from selectionData
-    // because computed position will point to the page where the position is in currentMonthRange
-    // and this can lead to bugs when we mutate the wrong page.
     var selectionYm = YearMonth(0)
 
     // internal as used in tests
@@ -168,7 +164,7 @@ internal class RangeCalendarPagerAdapter(
         val changed = set()
 
         if (notify && changed) {
-            notifyItemRangeChanged(0, count, Payload.onStylePropertyChanged(styleIndex))
+            notifyAllPages(Payload.onStylePropertyChanged(styleIndex))
         }
     }
 
@@ -184,7 +180,7 @@ internal class RangeCalendarPagerAdapter(
     inline fun setStyleBool(getStyle: GetCalendarStyleProp, value: Boolean, notify: Boolean = true) =
         setStylePacked(getStyle, PackedInt(value), notify)
 
-    inline fun <T : Enum<T>> setStyleEnum(getStyle: GetCalendarStyleProp, value: T, notify: Boolean = true) =
+    inline fun setStyleEnum(getStyle: GetCalendarStyleProp, value: Enum<*>, notify: Boolean = true) =
         setStylePacked(getStyle, PackedInt(value), notify)
 
     inline fun setStyleObject(getStyle: GetCalendarStyleProp, data: Any?, notify: Boolean = true) =

--- a/library/src/main/java/com/github/pelmenstar1/rangecalendar/RangeCalendarStyleData.kt
+++ b/library/src/main/java/com/github/pelmenstar1/rangecalendar/RangeCalendarStyleData.kt
@@ -48,13 +48,11 @@ internal class RangeCalendarStyleData {
         return old != value
     }
 
-    inline fun forEachIntStyle(block: (propIndex: Int) -> Unit) {
+    inline fun forEachProperty(block: (propIndex: Int) -> Unit) {
         for (propIndex in 0 until INT_PROPS_COUNT) {
             block(propIndex)
         }
-    }
 
-    inline fun forEachObjectStyle(block: (propIndex: Int) -> Unit) {
         for (propIndex in OBJECT_PROP_START until (OBJECT_PROP_START + OBJECT_PROPS_COUNT)) {
             block(propIndex)
         }

--- a/library/src/main/java/com/github/pelmenstar1/rangecalendar/RangeCalendarStyleData.kt
+++ b/library/src/main/java/com/github/pelmenstar1/rangecalendar/RangeCalendarStyleData.kt
@@ -1,0 +1,156 @@
+package com.github.pelmenstar1.rangecalendar
+
+import android.graphics.Typeface
+import com.github.pelmenstar1.rangecalendar.selection.CellAnimationType
+import com.github.pelmenstar1.rangecalendar.selection.DefaultSelectionManager
+
+internal typealias GetCalendarStyleProp = RangeCalendarStyleData.Companion.() -> Int
+
+internal class RangeCalendarStyleData {
+    private val propInts = IntArray(INT_PROPS_COUNT)
+    private val propObjects = arrayOfNulls<Any>(OBJECT_PROPS_COUNT)
+
+    fun getPackedInt(propIndex: Int) = PackedInt(propInts[propIndex])
+
+    fun getInt(propIndex: Int) = getPackedInt(propIndex).value
+    fun getFloat(propIndex: Int) = getPackedInt(propIndex).float()
+    fun getBoolean(propIndex: Int) = getPackedInt(propIndex).boolean()
+
+    inline fun getPackedInt(getProp: GetCalendarStyleProp) = getPackedInt(getProp(Companion))
+
+    inline fun getInt(getProp: GetCalendarStyleProp) = getPackedInt(getProp).value
+    inline fun getFloat(getProp: GetCalendarStyleProp) = getPackedInt(getProp).float()
+    inline fun getBoolean(getProp: GetCalendarStyleProp) = getPackedInt(getProp).boolean()
+
+    @Suppress("UNCHECKED_CAST")
+    fun <T> getObject(propIndex: Int) = propObjects[propIndex - OBJECT_PROP_START] as T
+
+    inline fun <T> getObject(getProp: GetCalendarStyleProp) = getObject<T>(getProp(Companion))
+
+    fun set(propIndex: Int, value: Int) = set(propIndex, PackedInt(value))
+    fun set(propIndex: Int, value: Float) = set(propIndex, PackedInt(value))
+    fun set(propIndex: Int, value: Boolean) = set(propIndex, PackedInt(value))
+    fun <T : Enum<T>> set(propIndex: Int, value: T) =
+        set(propIndex, PackedInt(value.ordinal))
+
+    fun set(propIndex: Int, packed: PackedInt): Boolean {
+        val old = propInts[propIndex]
+        propInts[propIndex] = packed.value
+
+        return old != packed.value
+    }
+
+    fun set(propIndex: Int, value: Any?): Boolean {
+        val objIndex = propIndex - OBJECT_PROP_START
+
+        val old = propObjects[objIndex]
+        propObjects[objIndex] = value
+
+        return old != value
+    }
+
+    inline fun forEachIntStyle(block: (propIndex: Int) -> Unit) {
+        for (propIndex in 0 until INT_PROPS_COUNT) {
+            block(propIndex)
+        }
+    }
+
+    inline fun forEachObjectStyle(block: (propIndex: Int) -> Unit) {
+        for (propIndex in OBJECT_PROP_START until (OBJECT_PROP_START + OBJECT_PROPS_COUNT)) {
+            block(propIndex)
+        }
+    }
+
+    companion object {
+        const val INT_PROPS_COUNT = 20
+        const val OBJECT_PROPS_COUNT = 8
+
+        const val OBJECT_PROP_START = 32
+
+        // These are properties that can be stored in int32
+        const val DAY_NUMBER_TEXT_SIZE = 0
+        const val WEEKDAY_TEXT_SIZE = 1
+        const val CELL_ROUND_RADIUS = 2
+        const val CELL_WIDTH = 3
+        const val CELL_HEIGHT = 4
+        const val WEEKDAY_TYPE = 5
+        const val CLICK_ON_CELL_SELECTION_BEHAVIOR = 6
+        const val COMMON_ANIMATION_DURATION = 7
+        const val HOVER_ANIMATION_DURATION = 8
+        const val VIBRATE_ON_SELECTING_RANGE = 9
+        const val SELECTION_FILL_GRADIENT_BOUNDS_TYPE = 10
+        const val CELL_ANIMATION_TYPE = 11
+        const val IN_MONTH_TEXT_COLOR = 12
+        const val OUT_MONTH_TEXT_COLOR = 13
+        const val DISABLED_TEXT_COLOR = 14
+        const val TODAY_TEXT_COLOR = 15
+        const val WEEKDAY_TEXT_COLOR = 16
+        const val HOVER_COLOR = 17
+        const val HOVER_ON_SELECTION_COLOR = 18
+        const val SHOW_ADJACENT_MONTHS = 19
+
+
+
+        // These are properties that can be stored as an object
+        const val COMMON_ANIMATION_INTERPOLATOR = 32
+        const val HOVER_ANIMATION_INTERPOLATOR = 33
+        const val DECOR_DEFAULT_LAYOUT_OPTIONS = 34
+        const val SELECTION_FILL = 35
+        const val SELECTION_MANAGER = 36
+        const val CELL_ACCESSIBILITY_INFO_PROVIDER = 37
+        const val WEEKDAY_TYPEFACE = 38
+        const val WEEKDAYS = 39
+
+        fun isObjectProperty(propIndex: Int) = propIndex >= OBJECT_PROP_START
+
+        fun default(cr: CalendarResources): RangeCalendarStyleData {
+            return RangeCalendarStyleData().apply {
+                // colors
+                set(IN_MONTH_TEXT_COLOR, cr.textColor)
+                set(OUT_MONTH_TEXT_COLOR, cr.outMonthTextColor)
+                set(DISABLED_TEXT_COLOR, cr.disabledTextColor)
+                set(TODAY_TEXT_COLOR, cr.colorPrimary)
+                set(WEEKDAY_TEXT_COLOR, cr.textColor)
+                set(HOVER_COLOR, cr.hoverColor)
+                set(HOVER_ON_SELECTION_COLOR, cr.colorPrimaryDark)
+
+                // sizes
+                set(DAY_NUMBER_TEXT_SIZE, cr.dayNumberTextSize)
+                set(WEEKDAY_TEXT_SIZE, cr.weekdayTextSize)
+                set(WEEKDAY_TYPE, WeekdayType.SHORT)
+                set(CELL_ROUND_RADIUS, Float.POSITIVE_INFINITY)
+                set(CELL_WIDTH, cr.cellSize)
+                set(CELL_HEIGHT, cr.cellSize)
+
+                // typefaces
+                set(WEEKDAY_TYPEFACE, Typeface.DEFAULT_BOLD)
+
+                // animations
+                set(COMMON_ANIMATION_DURATION, 250)
+                set(HOVER_ANIMATION_DURATION, 100)
+
+                set(COMMON_ANIMATION_INTERPOLATOR, LINEAR_INTERPOLATOR)
+                set(HOVER_ANIMATION_INTERPOLATOR, LINEAR_INTERPOLATOR)
+
+                set(CELL_ANIMATION_TYPE, CellAnimationType.ALPHA)
+
+                // selection
+                set(SELECTION_FILL, Fill.solid(cr.colorPrimary))
+                set(SELECTION_MANAGER, DefaultSelectionManager())
+                set(
+                    SELECTION_FILL_GRADIENT_BOUNDS_TYPE,
+                    SelectionFillGradientBoundsType.GRID
+                )
+
+                // other stuff
+                set(VIBRATE_ON_SELECTING_RANGE, true)
+                set(SHOW_ADJACENT_MONTHS, true)
+                set(WEEKDAYS, null)
+                set(
+                    CLICK_ON_CELL_SELECTION_BEHAVIOR,
+                    ClickOnCellSelectionBehavior.NONE
+                )
+            }
+        }
+    }
+}

--- a/library/src/main/java/com/github/pelmenstar1/rangecalendar/RangeCalendarStyleData.kt
+++ b/library/src/main/java/com/github/pelmenstar1/rangecalendar/RangeCalendarStyleData.kt
@@ -30,8 +30,7 @@ internal class RangeCalendarStyleData {
     fun set(propIndex: Int, value: Int) = set(propIndex, PackedInt(value))
     fun set(propIndex: Int, value: Float) = set(propIndex, PackedInt(value))
     fun set(propIndex: Int, value: Boolean) = set(propIndex, PackedInt(value))
-    fun <T : Enum<T>> set(propIndex: Int, value: T) =
-        set(propIndex, PackedInt(value.ordinal))
+    fun set(propIndex: Int, value: Enum<*>) = set(propIndex, PackedInt(value.ordinal))
 
     fun set(propIndex: Int, packed: PackedInt): Boolean {
         val old = propInts[propIndex]
@@ -88,8 +87,6 @@ internal class RangeCalendarStyleData {
         const val HOVER_COLOR = 17
         const val HOVER_ON_SELECTION_COLOR = 18
         const val SHOW_ADJACENT_MONTHS = 19
-
-
 
         // These are properties that can be stored as an object
         const val COMMON_ANIMATION_INTERPOLATOR = 32

--- a/library/src/main/java/com/github/pelmenstar1/rangecalendar/RangeCalendarView.kt
+++ b/library/src/main/java/com/github/pelmenstar1/rangecalendar/RangeCalendarView.kt
@@ -115,8 +115,6 @@ class RangeCalendarView @JvmOverloads constructor(
         fun onPageChanged(year: Int, month: Int)
     }
 
-    // Kotlin says that there's redundant qualitifer in RangeCalendarPagerAdapter.getStyle() but it's wrong.
-    @Suppress("RemoveRedundantQualifierName")
     private class ExtractAttributesScope(
         private val calendarView: RangeCalendarView,
         private val attrs: TypedArray
@@ -155,23 +153,23 @@ class RangeCalendarView @JvmOverloads constructor(
 
         inline fun color(
             @StyleableRes index: Int,
-            getStyle: RangeCalendarPagerAdapter.Companion.() -> Int
-        ) = color(index, RangeCalendarPagerAdapter.getStyle())
+            getStyle: GetCalendarStyleProp
+        ) = color(index, getStyle(RangeCalendarStyleData.Companion))
 
         inline fun dimension(
             @StyleableRes index: Int,
-            getStyle: RangeCalendarPagerAdapter.Companion.() -> Int
-        ) = dimension(index, RangeCalendarPagerAdapter.getStyle())
+            getStyle: GetCalendarStyleProp
+        ) = dimension(index, getStyle(RangeCalendarStyleData.Companion))
 
         inline fun int(
             @StyleableRes index: Int,
-            getStyle: RangeCalendarPagerAdapter.Companion.() -> Int
-        ) = int(index, RangeCalendarPagerAdapter.getStyle())
+            getStyle: GetCalendarStyleProp
+        ) = int(index, getStyle(RangeCalendarStyleData.Companion))
 
         inline fun boolean(
             @StyleableRes index: Int,
-            getStyle: RangeCalendarPagerAdapter.Companion.() -> Int
-        ) = boolean(index, RangeCalendarPagerAdapter.getStyle())
+            getStyle: GetCalendarStyleProp
+        ) = boolean(index, getStyle(RangeCalendarStyleData.Companion))
 
         private inline fun <T> extractPrimitive(
             @StyleableRes index: Int,
@@ -237,7 +235,7 @@ class RangeCalendarView @JvmOverloads constructor(
         adapter = RangeCalendarPagerAdapter(cr).apply {
             setToday(today)
             setStyleObject(
-                { STYLE_CELL_ACCESSIBILITY_INFO_PROVIDER },
+                { CELL_ACCESSIBILITY_INFO_PROVIDER },
                 DefaultRangeCalendarCellAccessibilityInfoProvider(context),
                 notify = false
             )
@@ -376,22 +374,22 @@ class RangeCalendarView @JvmOverloads constructor(
                     setSelectionColor(color)
                 }
 
-                color(R.styleable.RangeCalendarView_rangeCalendar_inMonthDayNumberColor) { STYLE_IN_MONTH_TEXT_COLOR }
-                color(R.styleable.RangeCalendarView_rangeCalendar_outMonthDayNumberColor) { STYLE_OUT_MONTH_TEXT_COLOR }
-                color(R.styleable.RangeCalendarView_rangeCalendar_disabledDayNumberColor) { STYLE_DISABLED_TEXT_COLOR }
-                color(R.styleable.RangeCalendarView_rangeCalendar_todayColor) { STYLE_TODAY_TEXT_COLOR }
-                color(R.styleable.RangeCalendarView_rangeCalendar_weekdayColor) { STYLE_WEEKDAY_TEXT_COLOR }
-                color(R.styleable.RangeCalendarView_rangeCalendar_hoverColor) { STYLE_HOVER_COLOR }
-                color(R.styleable.RangeCalendarView_rangeCalendar_hoverOnSelectionColor) { STYLE_HOVER_ON_SELECTION_COLOR }
-                dimension(R.styleable.RangeCalendarView_rangeCalendar_dayNumberTextSize) { STYLE_DAY_NUMBER_TEXT_SIZE }
-                dimension(R.styleable.RangeCalendarView_rangeCalendar_weekdayTextSize) { STYLE_WEEKDAY_TEXT_SIZE }
-                int(R.styleable.RangeCalendarView_rangeCalendar_weekdayType) { STYLE_WEEKDAY_TYPE }
-                int(R.styleable.RangeCalendarView_rangeCalendar_clickOnCellSelectionBehavior) { STYLE_CLICK_ON_CELL_SELECTION_BEHAVIOR }
-                dimension(R.styleable.RangeCalendarView_rangeCalendar_cellRoundRadius) { STYLE_CELL_RR_RADIUS }
-                boolean(R.styleable.RangeCalendarView_rangeCalendar_vibrateOnSelectingCustomRange) { STYLE_VIBRATE_ON_SELECTING_CUSTOM_RANGE }
-                int(R.styleable.RangeCalendarView_rangeCalendar_selectionFillGradientBoundsType) { STYLE_SELECTION_FILL_GRADIENT_BOUNDS_TYPE }
-                int(R.styleable.RangeCalendarView_rangeCalendar_cellAnimationType) { STYLE_CELL_ANIMATION_TYPE }
-                boolean(R.styleable.RangeCalendarView_rangeCalendar_showAdjacentMonths) { STYLE_SHOW_ADJACENT_MONTHS }
+                color(R.styleable.RangeCalendarView_rangeCalendar_inMonthDayNumberColor) { IN_MONTH_TEXT_COLOR }
+                color(R.styleable.RangeCalendarView_rangeCalendar_outMonthDayNumberColor) { OUT_MONTH_TEXT_COLOR }
+                color(R.styleable.RangeCalendarView_rangeCalendar_disabledDayNumberColor) { DISABLED_TEXT_COLOR }
+                color(R.styleable.RangeCalendarView_rangeCalendar_todayColor) { TODAY_TEXT_COLOR }
+                color(R.styleable.RangeCalendarView_rangeCalendar_weekdayColor) { WEEKDAY_TEXT_COLOR }
+                color(R.styleable.RangeCalendarView_rangeCalendar_hoverColor) { HOVER_COLOR }
+                color(R.styleable.RangeCalendarView_rangeCalendar_hoverOnSelectionColor) { HOVER_ON_SELECTION_COLOR }
+                dimension(R.styleable.RangeCalendarView_rangeCalendar_dayNumberTextSize) { DAY_NUMBER_TEXT_SIZE }
+                dimension(R.styleable.RangeCalendarView_rangeCalendar_weekdayTextSize) { WEEKDAY_TEXT_SIZE }
+                int(R.styleable.RangeCalendarView_rangeCalendar_weekdayType) { WEEKDAY_TYPE }
+                int(R.styleable.RangeCalendarView_rangeCalendar_clickOnCellSelectionBehavior) { CLICK_ON_CELL_SELECTION_BEHAVIOR }
+                dimension(R.styleable.RangeCalendarView_rangeCalendar_cellRoundRadius) { CELL_ROUND_RADIUS }
+                boolean(R.styleable.RangeCalendarView_rangeCalendar_vibrateOnSelectingCustomRange) { VIBRATE_ON_SELECTING_RANGE }
+                int(R.styleable.RangeCalendarView_rangeCalendar_selectionFillGradientBoundsType) { SELECTION_FILL_GRADIENT_BOUNDS_TYPE }
+                int(R.styleable.RangeCalendarView_rangeCalendar_cellAnimationType) { CELL_ANIMATION_TYPE }
+                boolean(R.styleable.RangeCalendarView_rangeCalendar_showAdjacentMonths) { SHOW_ADJACENT_MONTHS }
 
 
                 // cellSize, cellWidth, cellHeight require special logic.
@@ -417,11 +415,11 @@ class RangeCalendarView @JvmOverloads constructor(
                     adapter.setCellSize(cellWidth)
                 } else {
                     if (!cellWidth.isNaN()) {
-                        adapter.setStyleFloat({ STYLE_CELL_WIDTH }, cellWidth)
+                        adapter.setStyleFloat({ CELL_WIDTH }, cellWidth)
                     }
 
                     if (!cellHeight.isNaN()) {
-                        adapter.setStyleFloat({ STYLE_CELL_HEIGHT }, cellHeight)
+                        adapter.setStyleFloat({ CELL_HEIGHT }, cellHeight)
                     }
                 }
 
@@ -803,9 +801,9 @@ class RangeCalendarView @JvmOverloads constructor(
      * by default it's solid color which color is extracted from [androidx.appcompat.R.attr.colorPrimary]
      */
     var selectionFill: Fill
-        get() = adapter.getStyleObject { STYLE_SELECTION_FILL }
+        get() = adapter.getStyleObject { SELECTION_FILL }
         set(value) {
-            adapter.setStyleObject({ STYLE_SELECTION_FILL }, value)
+            adapter.setStyleObject({ SELECTION_FILL }, value)
         }
 
     /**
@@ -823,20 +821,20 @@ class RangeCalendarView @JvmOverloads constructor(
      */
     var selectionFillGradientBoundsType: SelectionFillGradientBoundsType
         get() = adapter.getStyleEnum(
-            { STYLE_SELECTION_FILL_GRADIENT_BOUNDS_TYPE },
+            { SELECTION_FILL_GRADIENT_BOUNDS_TYPE },
             SelectionFillGradientBoundsType::ofOrdinal
         )
         set(value) {
-            adapter.setStyleEnum({ STYLE_SELECTION_FILL_GRADIENT_BOUNDS_TYPE }, value)
+            adapter.setStyleEnum({ SELECTION_FILL_GRADIENT_BOUNDS_TYPE }, value)
         }
 
     /**
      * Gets or sets a text size of day number, in pixels
      */
     var dayNumberTextSize: Float
-        get() = adapter.getStyleFloat { STYLE_DAY_NUMBER_TEXT_SIZE }
+        get() = adapter.getStyleFloat { DAY_NUMBER_TEXT_SIZE }
         set(size) {
-            adapter.setStyleFloat({ STYLE_DAY_NUMBER_TEXT_SIZE }, size)
+            adapter.setStyleFloat({ DAY_NUMBER_TEXT_SIZE }, size)
         }
 
     /**
@@ -844,9 +842,9 @@ class RangeCalendarView @JvmOverloads constructor(
      */
     @get:ColorInt
     var inMonthDayNumberColor: Int
-        get() = adapter.getStyleInt { STYLE_IN_MONTH_TEXT_COLOR }
+        get() = adapter.getStyleInt { IN_MONTH_TEXT_COLOR }
         set(@ColorInt color) {
-            adapter.setStyleInt({ STYLE_IN_MONTH_TEXT_COLOR }, color)
+            adapter.setStyleInt({ IN_MONTH_TEXT_COLOR }, color)
         }
 
     /**
@@ -854,9 +852,9 @@ class RangeCalendarView @JvmOverloads constructor(
      */
     @get:ColorInt
     var outMonthDayNumberColor: Int
-        get() = adapter.getStyleInt { STYLE_OUT_MONTH_TEXT_COLOR }
+        get() = adapter.getStyleInt { OUT_MONTH_TEXT_COLOR }
         set(@ColorInt color) {
-            adapter.setStyleInt({ STYLE_OUT_MONTH_TEXT_COLOR }, color)
+            adapter.setStyleInt({ OUT_MONTH_TEXT_COLOR }, color)
         }
 
 
@@ -865,9 +863,9 @@ class RangeCalendarView @JvmOverloads constructor(
      */
     @get:ColorInt
     var disabledDayNumberColor: Int
-        get() = adapter.getStyleInt { STYLE_DISABLED_TEXT_COLOR }
+        get() = adapter.getStyleInt { DISABLED_TEXT_COLOR }
         set(@ColorInt color) {
-            adapter.setStyleInt({ STYLE_DISABLED_TEXT_COLOR }, color)
+            adapter.setStyleInt({ DISABLED_TEXT_COLOR }, color)
         }
 
     /**
@@ -876,9 +874,9 @@ class RangeCalendarView @JvmOverloads constructor(
      */
     @get:ColorInt
     var todayColor: Int
-        get() = adapter.getStyleInt { STYLE_TODAY_TEXT_COLOR }
+        get() = adapter.getStyleInt { TODAY_TEXT_COLOR }
         set(@ColorInt color) {
-            adapter.setStyleInt({ STYLE_TODAY_TEXT_COLOR }, color)
+            adapter.setStyleInt({ TODAY_TEXT_COLOR }, color)
         }
 
     /**
@@ -887,27 +885,27 @@ class RangeCalendarView @JvmOverloads constructor(
      */
     @get:ColorInt
     var weekdayColor: Int
-        get() = adapter.getStyleInt { STYLE_WEEKDAY_TEXT_COLOR }
+        get() = adapter.getStyleInt { WEEKDAY_TEXT_COLOR }
         set(@ColorInt color) {
-            adapter.setStyleInt({ STYLE_WEEKDAY_TEXT_COLOR }, color)
+            adapter.setStyleInt({ WEEKDAY_TEXT_COLOR }, color)
         }
 
     /**
      * Gets or sets a text size of weekday, in pixels
      */
     var weekdayTextSize: Float
-        get() = adapter.getStyleFloat { STYLE_WEEKDAY_TEXT_SIZE }
+        get() = adapter.getStyleFloat { WEEKDAY_TEXT_SIZE }
         set(size) {
-            adapter.setStyleFloat({ STYLE_WEEKDAY_TEXT_SIZE }, size)
+            adapter.setStyleFloat({ WEEKDAY_TEXT_SIZE }, size)
         }
 
     /**
      * Gets or sets a typeface of weekday. Pass null to clear previous typeface.
      */
     var weekdayTypeface: Typeface?
-        get() = adapter.getStyleObject { STYLE_WEEKDAY_TYPEFACE }
+        get() = adapter.getStyleObject { WEEKDAY_TYPEFACE }
         set(value) {
-            adapter.setStyleObject({ STYLE_WEEKDAY_TYPEFACE }, value)
+            adapter.setStyleObject({ WEEKDAY_TYPEFACE }, value)
         }
 
     /**
@@ -919,14 +917,14 @@ class RangeCalendarView @JvmOverloads constructor(
      * Pass `null` to use localized weekdays. Note that if you do that, the getter will return localized weekdays, not `null`.
      */
     var weekdays: Array<out String>?
-        get() = adapter.getStyleObject { STYLE_WEEKDAYS }
+        get() = adapter.getStyleObject { WEEKDAYS }
         set(value) {
             if (value != null && value.size != 7) {
                 throw IllegalArgumentException("Length of the array should be 7")
             }
 
             // Copy the array because the caller might be it later.
-            adapter.setStyleObject({ STYLE_WEEKDAYS }, value?.copyOf())
+            adapter.setStyleObject({ WEEKDAYS }, value?.copyOf())
         }
 
     /**
@@ -937,9 +935,9 @@ class RangeCalendarView @JvmOverloads constructor(
      */
     @get:ColorInt
     var hoverColor: Int
-        get() = adapter.getStyleInt { STYLE_HOVER_COLOR }
+        get() = adapter.getStyleInt { HOVER_COLOR }
         set(color) {
-            adapter.setStyleInt({ STYLE_HOVER_COLOR }, color)
+            adapter.setStyleInt({ HOVER_COLOR }, color)
         }
 
     /**
@@ -948,9 +946,9 @@ class RangeCalendarView @JvmOverloads constructor(
      */
     @get:ColorInt
     var hoverOnSelectionColor: Int
-        get() = adapter.getStyleInt { STYLE_HOVER_ON_SELECTION_COLOR }
+        get() = adapter.getStyleInt { HOVER_ON_SELECTION_COLOR }
         set(color) {
-            adapter.setStyleInt({ STYLE_HOVER_ON_SELECTION_COLOR }, color)
+            adapter.setStyleInt({ HOVER_ON_SELECTION_COLOR }, color)
         }
 
     /**
@@ -960,9 +958,9 @@ class RangeCalendarView @JvmOverloads constructor(
      * Set to [Float.POSITIVE_INFINITY] if cell shape is wanted to be circle regardless the size of it.
      */
     var cellRoundRadius: Float
-        get() = adapter.getStyleFloat { STYLE_CELL_RR_RADIUS }
+        get() = adapter.getStyleFloat { CELL_ROUND_RADIUS }
         set(ratio) {
-            adapter.setStyleFloat({ STYLE_CELL_RR_RADIUS }, ratio)
+            adapter.setStyleFloat({ CELL_ROUND_RADIUS }, ratio)
         }
 
     /**
@@ -974,6 +972,8 @@ class RangeCalendarView @JvmOverloads constructor(
     var cellSize: Float
         get() = max(cellWidth, cellHeight)
         set(size) {
+            require(size > 0) { "Cell size should be positive" }
+
             adapter.setCellSize(size)
         }
 
@@ -981,18 +981,22 @@ class RangeCalendarView @JvmOverloads constructor(
      * Gets or sets width of cells, in pixels, should be greater than 0.
      */
     var cellWidth: Float
-        get() = adapter.getStyleFloat { STYLE_CELL_WIDTH }
+        get() = adapter.getStyleFloat { CELL_WIDTH }
         set(value) {
-            adapter.setStyleFloat({ STYLE_CELL_WIDTH }, value)
+            require(value > 0) { "Cell width should be positive" }
+
+            adapter.setStyleFloat({ CELL_WIDTH }, value)
         }
 
     /**
      * Gets or sets height of cells, in pixels, should be greater than 0.
      */
     var cellHeight: Float
-        get() = adapter.getStyleFloat { STYLE_CELL_HEIGHT }
+        get() = adapter.getStyleFloat { CELL_HEIGHT }
         set(value) {
-            adapter.setStyleFloat({ STYLE_CELL_HEIGHT }, value)
+            require(value > 0) { "Cell height should be positive" }
+
+            adapter.setStyleFloat({ CELL_HEIGHT }, value)
         }
 
     /**
@@ -1010,9 +1014,9 @@ class RangeCalendarView @JvmOverloads constructor(
      * @throws IllegalArgumentException if type is not one of [WeekdayType] constants
      */
     var weekdayType: WeekdayType
-        get() = adapter.getStyleEnum({ STYLE_WEEKDAY_TYPE }, WeekdayType::ofOrdinal)
+        get() = adapter.getStyleEnum({ WEEKDAY_TYPE }, WeekdayType::ofOrdinal)
         set(type) {
-            adapter.setStyleEnum({ STYLE_WEEKDAY_TYPE }, type)
+            adapter.setStyleEnum({ WEEKDAY_TYPE }, type)
         }
 
     /**
@@ -1021,11 +1025,11 @@ class RangeCalendarView @JvmOverloads constructor(
     var clickOnCellSelectionBehavior: ClickOnCellSelectionBehavior
         get() {
             return adapter.getStyleEnum(
-                { STYLE_CLICK_ON_CELL_SELECTION_BEHAVIOR }, ClickOnCellSelectionBehavior::ofOrdinal
+                { CLICK_ON_CELL_SELECTION_BEHAVIOR }, ClickOnCellSelectionBehavior::ofOrdinal
             )
         }
         set(value) {
-            adapter.setStyleEnum({ STYLE_CLICK_ON_CELL_SELECTION_BEHAVIOR }, value)
+            adapter.setStyleEnum({ CLICK_ON_CELL_SELECTION_BEHAVIOR }, value)
         }
 
     /**
@@ -1035,10 +1039,10 @@ class RangeCalendarView @JvmOverloads constructor(
      * @throws IllegalArgumentException if duration is negative
      */
     var commonAnimationDuration: Int
-        get() = adapter.getStyleInt { STYLE_COMMON_ANIMATION_DURATION }
+        get() = adapter.getStyleInt { COMMON_ANIMATION_DURATION }
         set(duration) {
             require(duration >= 0) { "duration" }
-            adapter.setStyleInt({ STYLE_COMMON_ANIMATION_DURATION }, duration)
+            adapter.setStyleInt({ COMMON_ANIMATION_DURATION }, duration)
         }
 
     /**
@@ -1046,9 +1050,9 @@ class RangeCalendarView @JvmOverloads constructor(
      * By default, the interpolator is linear.
      */
     var commonAnimationInterpolator: TimeInterpolator
-        get() = adapter.getStyleObject { STYLE_COMMON_ANIMATION_INTERPOLATOR }
+        get() = adapter.getStyleObject { COMMON_ANIMATION_INTERPOLATOR }
         set(value) {
-            adapter.setStyleObject({ STYLE_COMMON_ANIMATION_INTERPOLATOR }, value)
+            adapter.setStyleObject({ COMMON_ANIMATION_INTERPOLATOR }, value)
         }
 
     /**
@@ -1057,47 +1061,47 @@ class RangeCalendarView @JvmOverloads constructor(
      * @throws IllegalArgumentException if duration is negative
      */
     var hoverAnimationDuration: Int
-        get() = adapter.getStyleInt { STYLE_HOVER_ANIMATION_DURATION }
+        get() = adapter.getStyleInt { HOVER_ANIMATION_DURATION }
         set(duration) {
             require(duration >= 0) { "duration" }
 
-            adapter.setStyleInt({ STYLE_HOVER_ANIMATION_DURATION }, duration)
+            adapter.setStyleInt({ HOVER_ANIMATION_DURATION }, duration)
         }
 
     /**
      * Gets or sets time interpolator of hover animation.
      */
     var hoverAnimationInterpolator: TimeInterpolator
-        get() = adapter.getStyleObject { STYLE_HOVER_ANIMATION_INTERPOLATOR }
+        get() = adapter.getStyleObject { HOVER_ANIMATION_INTERPOLATOR }
         set(value) {
-            adapter.setStyleObject({ STYLE_HOVER_ANIMATION_INTERPOLATOR }, value)
+            adapter.setStyleObject({ HOVER_ANIMATION_INTERPOLATOR }, value)
         }
 
     /**
      * Gets or sets whether device should vibrate when user starts to select custom range.
      */
     var vibrateOnSelectingCustomRange: Boolean
-        get() = adapter.getStyleBool { STYLE_VIBRATE_ON_SELECTING_CUSTOM_RANGE }
+        get() = adapter.getStyleBool { VIBRATE_ON_SELECTING_RANGE }
         set(state) {
-            adapter.setStyleBool({ STYLE_VIBRATE_ON_SELECTING_CUSTOM_RANGE }, state)
+            adapter.setStyleBool({ VIBRATE_ON_SELECTING_RANGE }, state)
         }
 
     /**
      * Gets or sets animation type for cells.
      */
     var cellAnimationType: CellAnimationType
-        get() = adapter.getStyleEnum({ STYLE_CELL_ANIMATION_TYPE }, CellAnimationType::ofOrdinal)
+        get() = adapter.getStyleEnum({ CELL_ANIMATION_TYPE }, CellAnimationType::ofOrdinal)
         set(type) {
-            adapter.setStyleEnum({ STYLE_CELL_ANIMATION_TYPE }, type)
+            adapter.setStyleEnum({ CELL_ANIMATION_TYPE }, type)
         }
 
     /**
      * Gets or sets whether adjacent month should be shown on the calendar page. By default, it's `true`.
      */
     var showAdjacentMonths: Boolean
-        get() = adapter.getStyleBool { STYLE_SHOW_ADJACENT_MONTHS }
+        get() = adapter.getStyleBool { SHOW_ADJACENT_MONTHS }
         set(value) {
-            adapter.setStyleBool({ STYLE_SHOW_ADJACENT_MONTHS }, value)
+            adapter.setStyleBool({ SHOW_ADJACENT_MONTHS }, value)
         }
 
     /**
@@ -1132,9 +1136,9 @@ class RangeCalendarView @JvmOverloads constructor(
      * responsible of providing accessibility-related information about cells in the calendar.
      */
     var cellAccessibilityInfoProvider: RangeCalendarCellAccessibilityInfoProvider
-        get() = adapter.getStyleObject { STYLE_CELL_ACCESSIBILITY_INFO_PROVIDER }
+        get() = adapter.getStyleObject { CELL_ACCESSIBILITY_INFO_PROVIDER }
         set(value) {
-            adapter.setStyleObject({ STYLE_CELL_ACCESSIBILITY_INFO_PROVIDER }, value)
+            adapter.setStyleObject({ CELL_ACCESSIBILITY_INFO_PROVIDER }, value)
         }
 
     /**
@@ -1329,7 +1333,7 @@ class RangeCalendarView @JvmOverloads constructor(
      * Sets custom implementation of selection manager. If you want to use default one, pass null as an argument.
      */
     fun setSelectionManager(selectionManager: SelectionManager?) {
-        adapter.setStyleObject({ STYLE_SELECTION_MANAGER }, selectionManager)
+        adapter.setStyleObject({ SELECTION_MANAGER }, selectionManager)
     }
 
     /**
@@ -1449,7 +1453,7 @@ class RangeCalendarView @JvmOverloads constructor(
     }
 
     fun setDecorationDefaultLayoutOptions(options: DecorLayoutOptions?) {
-        adapter.setStyleObject({ STYLE_DECOR_DEFAULT_LAYOUT_OPTIONS }, options)
+        adapter.setStyleObject({ DECOR_DEFAULT_LAYOUT_OPTIONS }, options)
     }
 
     private fun updateMoveButtons() {

--- a/library/src/test/java/com/github/pelmenstar1/rangecalendar/RangeCalendarStyleDataTests.kt
+++ b/library/src/test/java/com/github/pelmenstar1/rangecalendar/RangeCalendarStyleDataTests.kt
@@ -5,22 +5,17 @@ import kotlin.test.assertEquals
 
 class RangeCalendarStyleDataTests {
     @Test
-    fun forEachIntStyleTest() {
+    fun forEachPropertyTest() {
         val styleData = RangeCalendarStyleData()
 
-        // Checks whether internal int array has sufficient size. If not, out of bounds will happen.
-        styleData.forEachIntStyle { propIndex ->
-            styleData.getPackedInt(propIndex)
-        }
-    }
-
-    @Test
-    fun forEachObjectStyleTest() {
-        val styleData = RangeCalendarStyleData()
-
-        // Checks whether internal int array has sufficient size. If not, out of bounds will happen.
-        styleData.forEachObjectStyle { propIndex ->
-            styleData.getObject(propIndex)
+        // Checks whether internal int or object arrays have sufficient size.
+        // If not, out of bounds will happen.
+        styleData.forEachProperty { propIndex ->
+            if (RangeCalendarStyleData.isObjectProperty(propIndex)) {
+                styleData.getObject(propIndex)
+            } else {
+                styleData.getPackedInt(propIndex)
+            }
         }
     }
 

--- a/library/src/test/java/com/github/pelmenstar1/rangecalendar/RangeCalendarStyleDataTests.kt
+++ b/library/src/test/java/com/github/pelmenstar1/rangecalendar/RangeCalendarStyleDataTests.kt
@@ -1,0 +1,56 @@
+package com.github.pelmenstar1.rangecalendar
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class RangeCalendarStyleDataTests {
+    @Test
+    fun forEachIntStyleTest() {
+        val styleData = RangeCalendarStyleData()
+
+        // Checks whether internal int array has sufficient size. If not, out of bounds will happen.
+        styleData.forEachIntStyle { propIndex ->
+            styleData.getPackedInt(propIndex)
+        }
+    }
+
+    @Test
+    fun forEachObjectStyleTest() {
+        val styleData = RangeCalendarStyleData()
+
+        // Checks whether internal int array has sufficient size. If not, out of bounds will happen.
+        styleData.forEachObjectStyle { propIndex ->
+            styleData.getObject(propIndex)
+        }
+    }
+
+    @Test
+    fun setIntStyleTest() {
+        fun testCase(propIndex: Int, newValue: Int, expectedChanged: Boolean) {
+            val styleData = RangeCalendarStyleData()
+            val actualChanged = styleData.set(propIndex, newValue)
+            val actualValue = styleData.getInt(propIndex)
+
+            assertEquals(expectedChanged, actualChanged)
+            assertEquals(newValue, actualValue)
+        }
+
+        testCase(RangeCalendarStyleData.WEEKDAY_TYPE, newValue = 1, expectedChanged = true)
+        testCase(RangeCalendarStyleData.WEEKDAY_TEXT_SIZE, newValue = 0, expectedChanged = false)
+    }
+
+    @Test
+    fun setObjectStyleTest() {
+        fun testCase(propIndex: Int, newValue: Any?, expectedChanged: Boolean) {
+            val styleData = RangeCalendarStyleData()
+            val actualChanged = styleData.set(propIndex, newValue)
+            val actualValue = styleData.getObject<Any?>(propIndex)
+
+            assertEquals(expectedChanged, actualChanged)
+            assertEquals(newValue, actualValue)
+        }
+
+        testCase(RangeCalendarStyleData.WEEKDAYS, newValue = Any(), expectedChanged = true)
+        testCase(RangeCalendarStyleData.SELECTION_FILL, newValue = null, expectedChanged = false)
+    }
+}


### PR DESCRIPTION
- The style data is shared among all the calendars. This simplifies the logic a lot because we don't have to store it in both the adapter and grid-view
- Add  more tests